### PR TITLE
Improve Consistency and Clarity in batocera.conf

### DIFF
--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -243,6 +243,10 @@ updates.type=stable
 ## To check available outputs, run: batocera-resolution listOutputs
 #global.videooutput=""
 
+## Set the preferred resolution
+## To check available resolutions, run: batocera-resolution listModes
+#es.resolution=""
+
 ## DPI
 ## If the text is too small, adjust this value.
 #global.dpi=96


### PR DESCRIPTION
### Pull Request: Improve Consistency and Clarity in `batocera.conf`

This pull request aims to improve the consistency and clarity of how video settings are documented in `batocera.conf`.

---

### Current Issue

In the **Main Menu -> System Settings**, there are two related options:  
- **Video Output**  
- **Video Mode**

In `batocera.conf`, the **Video Output** is already well-documented with a dedicated section:  

```plaintext
## Set the preferred output
## To check available outputs, run: batocera-resolution listOutputs
global.videooutput=
```

However, the **Video Mode** setting (resolution and refresh rate) is saved at the end of the file without any clear documentation or explanation:  

```plaintext
es.resolution=XXXXxXXXX XXHZ
```

This inconsistency makes the file harder to read and less user-friendly.

---

### Proposed Solution

The **Video Mode** setting should have a dedicated, clearly marked section in `batocera.conf`, similar to **Video Output**. This section would include an explanation and reference to the appropriate command for listing available resolutions, making it easier for users to understand and configure.

Proposed update to `batocera.conf`:  

```plaintext
## Set the preferred output
## To check available outputs, run: batocera-resolution listOutputs
#global.videooutput=""

## Set the preferred resolution
## To check available resolutions, run: batocera-resolution listModes
#es.resolution=""
```