### PR TITLE
PCSX2 - 10:7 (1.43:1 - custom) aspect ratio

### DIFF
--- a/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
+++ b/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
@@ -77,6 +77,7 @@ cores:
           Auto Standard (4:3 interlaced / 3:2 progressive): Auto 4:3/3:2
           Standard (4:3): 4:3
           Widescreen (16:9): 16:9
+          "10:7 (1.43:1 — custom)": "10:7"
       pcsx2_fmv_ratio:
         submenu: DISPLAY
         prompt: FMV ASPECT RATIO
@@ -86,6 +87,7 @@ cores:
           Auto Standard (4:3 interlaced / 3:2 progressive): Auto 4:3/3:2
           Standard (4:3): 4:3
           Widescreen (16:9): 16:9
+          "10:7 (1.43:1 — custom)": "10:7"
       pcsx2_deinterlacing:
         submenu: DISPLAY
         prompt: DEINTERLACING


### PR DESCRIPTION
## Description

Add a `10:7 (1.43:1 - custom)` aspect ratio option for PCSX2 game rendering and FMV playback.

This provides an additional aspect ratio choice for users running PCSX2 on 4:3 displays, especially CRT displays, where correct horizontal scaling and geometry are important.

Some PS2 games do not line up perfectly with the existing 4:3 & Fit to Window / Fullscreen options when rendered through PCSX2. The new 10:7 option allows the image to be stretched more accurately so that the content better matches the intended presentation on original hardware.

## Changes

- Add `10:7 (1.43:1 - custom)` to `pcsx2_ratio`
- Add `10:7 (1.43:1 - custom)` to `pcsx2_fmv_ratio`